### PR TITLE
Fix Linux CMake build: restore XercesC and enable position-independent code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,11 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
 
+# Vendored externals (healpix_cxx, wcslib, ...) are static libraries that get
+# linked into shared libraries (libastro.so, SWIG python modules). Build every
+# target position-independent so the static archives can be linked into .so's.
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
 # Optional: forcibly propagate to all targets
 add_compile_options("$<$<COMPILE_LANGUAGE:CXX>:-std=c++17>")
 
@@ -56,6 +61,7 @@ set_target_properties(Python3::Python PROPERTIES IMPORTED_GLOBAL TRUE)
 
 if(NOT APPLE)
   option(USE_SYSTEM_CFITSIO     "Use system-installed cfitsio instead of package-provided" ON)
+  option(USE_SYSTEM_XERCES_C    "Use system-installed XercesC instead of package-provided" ON)
 else()
   option(USE_SYSTEM_CFITSIO     "Use system-installed cfitsio instead of package-provided" OFF)
 endif()
@@ -90,6 +96,7 @@ add_or_find(fftw         USE_SYSTEM_FFTW         FFTW         FFTW::fftw3)
 add_or_find(gsl          USE_SYSTEM_GSL          GSL          GSL::gsl)
 add_or_find(healpix_cxx  USE_SYSTEM_HEALPIX_CXX  healpix_cxx  healpix_cxx::healpix_cxx)
 add_or_find(wcslib       USE_SYSTEM_WCSLIB       WCSlib       WCSlib::WCSlib)
+add_or_find(xercesc      USE_SYSTEM_XERCES_C     XercesC      XercesC::XercesC)
 # -------------------------------------------------------------------------------------
 
 # Handle root.


### PR DESCRIPTION
## Summary

Two independent regressions were preventing a clean Linux developer build (following the [Developer Notes](https://github.com/fermi-lat/ScienceTools/wiki/Developer-Notes) CMake step). Both are fixed with small changes to the top-level `CMakeLists.txt`.

## 1. Configure failure — missing `XercesC::XercesC` target

The CMake **Generate** step failed with:

```
CMake Error at src/optimizers/CMakeLists.txt:28 (target_link_libraries):
  Target "optimizers" links to: XercesC::XercesC  but the target was not found.
CMake Error at src/xmlBase/CMakeLists.txt:17 (target_link_libraries):
  Target "xmlBase"    links to: XercesC::XercesC  but the target was not found.
```

**Cause.** Commit `87905c1` ("remove xerces from list") removed the
`add_or_find(xercesc ...)` line from `CMakeLists.txt`. That line was the *only*
place `find_package(XercesC)` was called and the *only* place the
`XercesC::XercesC` imported target was created. But `src/xmlBase` and
`src/optimizers` still link against `XercesC::XercesC`, so the removal left
those references dangling and Generate failed. The associated
`USE_SYSTEM_XERCES_C` option had also been dropped.

**Fix.** Restore the `USE_SYSTEM_XERCES_C` option (default `ON` on non-APPLE)
and the `add_or_find(xercesc USE_SYSTEM_XERCES_C XercesC XercesC::XercesC)` line.
Xerces-C is provided by the conda environment and located via CMake's bundled
`FindXercesC` module (`-- Found XercesC: .../libxerces-c.so (found version "3.3.0")`).

## 2. Link failure at ~78% — non-PIC vendored static libraries

After the configure fix, the build failed while linking `libastro.so`:

```
/usr/bin/ld: ../externals/healpix_cxx/libhealpix_cxx.a(error_handling.cc.o):
  relocation R_X86_64_PC32 against symbol `_ZTV11PlanckError'
  can not be used when making a shared object; recompile with -fPIC
/usr/bin/ld: final link failed: bad value
```

**Cause.** The vendored external static libraries (`healpix_cxx`, `wcslib`, ...)
were compiled without `-fPIC`, but they are linked into shared libraries such as
`libastro.so` and the SWIG-generated Python modules (`_pyLikelihood.so`, etc.).
On Linux, linking a non-PIC static archive into a shared object is an error. (The
`wcslib` `relocation against wcs_celerr in read-only section` message just above
was the same problem, one step less severe.)

**Fix.** Set `CMAKE_POSITION_INDEPENDENT_CODE ON` at the top level so every
target — including the vendored externals — is built position-independent.

## Verification

- `cmake -S . -B RelWithDebInfo ...` — configures and generates cleanly (exit 0).
- `cmake --build RelWithDebInfo -j$(nproc)` — compiles to **100%** (exit 0).
- `cmake --install RelWithDebInfo` — installs binaries, headers, libs, and Python
  bindings into the conda env (exit 0).
- `python -c "import pyLikelihood"` — succeeds from the installed environment.

## Notes

- The two remaining `libgomp.so.1 ... may be hidden` CMake warnings are unrelated
  and non-fatal (conda vs. system gcc OpenMP runtime); they do not affect the
  build or install.
- Change is scoped to Linux behavior (the `USE_SYSTEM_XERCES_C` option is defined
  in the non-APPLE branch, mirroring the pre-`87905c1` layout).
